### PR TITLE
Fix single leaderboard query

### DIFF
--- a/apiRoutes.js
+++ b/apiRoutes.js
@@ -247,7 +247,7 @@ var getRoutes = [
 						"WHERE leaderboard = $1",
 						"ORDER BY time"
 					].join(" ");
-					persistence.rawGet(query, [dataObj.leaderboard])
+					persistence.rawGet(query, [dataObj.id])
 						.then(function(dbData) {
 							dataObj.records = dbData;
 							resolve(dataObj);


### PR DESCRIPTION
The query for the records wasn't working because the leaderboard ID is in the `id` property, not the `leaderboard` property.
